### PR TITLE
Enable suggestion list on the iPhone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+#
+# Pods/

--- a/AutoComplete.xcodeproj/project.pbxproj
+++ b/AutoComplete.xcodeproj/project.pbxproj
@@ -232,7 +232,7 @@
 				INFOPLIST_FILE = "AutoComplete/AutoComplete-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = 2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -249,7 +249,7 @@
 				INFOPLIST_FILE = "AutoComplete/AutoComplete-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = 2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				WRAPPER_EXTENSION = app;
 			};

--- a/AutoComplete/AutoComplete-Info.plist
+++ b/AutoComplete/AutoComplete-Info.plist
@@ -26,6 +26,13 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>

--- a/AutoComplete/SuggestiveTextField.h
+++ b/AutoComplete/SuggestiveTextField.h
@@ -20,8 +20,8 @@
 // Filter array and reload TableView
 - (void)matchStrings:(NSString *)letters;
 
-// Present PopOver
-- (void)showPopOverList;
+// Present PopOver or Table View
+- (void)showSuggestionTableView;
 
 // Define if popover should hide after user selects a suggestion.
 @property BOOL shouldHideOnSelection;

--- a/AutoComplete/SuggestiveTextField.h
+++ b/AutoComplete/SuggestiveTextField.h
@@ -8,7 +8,7 @@
 #import <UIKit/UIKit.h>
 
 @interface SuggestiveTextField
-    : UITextField <UITextFieldDelegate, UITableViewDataSource,
+    : UITextField <UITableViewDataSource,
                    UITableViewDelegate>
 
 // Set suggestions list of NSString's.
@@ -22,6 +22,14 @@
 
 // Present PopOver or Table View
 - (void)showSuggestionTableView;
+
+- (void)dismissSuggestionTableView;
+
+// used for alignment of table view position
+// it should be set to the parent view that contains the text field
+// default: self.window
+@property (nonatomic, strong) UIView *referenceView;
+
 
 // Define if popover should hide after user selects a suggestion.
 @property BOOL shouldHideOnSelection;

--- a/AutoComplete/ViewController.xib
+++ b/AutoComplete/ViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="4514" systemVersion="12F45" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="6245" systemVersion="13F34" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment defaultVersion="1072" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3746"/>
+        <deployment defaultVersion="1536" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController">
@@ -16,23 +16,25 @@
             <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" clearButtonMode="whileEditing" id="3" customClass="SuggestiveTextField">
-                    <rect key="frame" x="230" y="186" width="309" height="31"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                    <textInputTraits key="textInputTraits" autocorrectionType="no"/>
-                </textField>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Type sth like Madrid, Amsterdam, Warsaw .." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" id="7">
-                    <rect key="frame" x="216" y="151" width="336" height="21"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Type sth like Madrid, Amsterdam, Warsaw .." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="7">
+                    <rect key="frame" x="8" y="8" width="279" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="3" customClass="SuggestiveTextField">
+                    <rect key="frame" x="8" y="37" width="265" height="30"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                    <textInputTraits key="textInputTraits" autocorrectionType="no"/>
+                </textField>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="blackOpaque"/>
-            <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
         </view>
     </objects>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination"/>
+    </simulatedMetricsContainer>
 </document>


### PR DESCRIPTION
The current suggestive text field uses a popover to enable suggestions on the iPad, however, it does not work on the iPhone. 
This commit tries to use the same table view controller to enable suggestions on the iPhone. It also changes the delegation class into self because the delegated methods need to interact with the popover or the table view to dismiss it if possible.
